### PR TITLE
Speedup multiupload by using mapM()

### DIFF
--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -113,7 +113,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
       .unit
 
   // only for file which are bigger than 5 Mb
-  def multipartUpload[R <: zio.Has[_]: Tagged](n: Int)(
+  def multipartUpload[R <: zio.Has[_]: Tagged](
     bucketName: String,
     key: String,
     contentType: String,
@@ -136,8 +136,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
                 .chunkN(5 * 1024 * 1024)
                 .chunks
                 .zipWithIndex
-                //TODO check with `mapM`
-                .mapMPar(n) {
+                .mapM {
                   case (chunk, partNumber) =>
                     execute(
                       _.uploadPart(

--- a/src/main/scala/zio/s3/Test.scala
+++ b/src/main/scala/zio/s3/Test.scala
@@ -111,7 +111,7 @@ object Test {
           S3ExceptionLike(new NotImplementedError("Not implemented error - please don't call execute() S3 Test mode"))
         )
 
-      override def multipartUpload[R <: zio.Has[_]: Tagged](n: Int)(
+      override def multipartUpload[R <: zio.Has[_]: Tagged](
         bucketName: String,
         key: String,
         contentType: String,

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -57,7 +57,7 @@ package object s3 {
         content: ZStreamChunk[R, Throwable, Byte]
       ): ZIO[R, S3Exception, Unit]
 
-      def multipartUpload[R <: zio.Has[_]: Tagged](n: Int)(
+      def multipartUpload[R <: zio.Has[_]: Tagged](
         bucketName: String,
         key: String,
         contentType: String,
@@ -141,13 +141,13 @@ package object s3 {
   ): ZIO[S3 with R, S3Exception, Unit] =
     ZIO.accessM[S3 with R](_.get.putObject(bucketName, key, contentLength, contentType, content))
 
-  def multipartUpload[R <: Has[_]: Tagged](n: Int)(
+  def multipartUpload[R <: Has[_]: Tagged](
     bucketName: String,
     key: String,
     contentType: String,
     content: ZStreamChunk[R, Throwable, Byte]
   ): ZIO[S3 with R, S3Exception, Unit] =
-    ZIO.accessM[S3 with R](_.get.multipartUpload(n)(bucketName, key, contentType, content))
+    ZIO.accessM[S3 with R](_.get.multipartUpload(bucketName, key, contentType, content))
 
   def execute[T](f: S3AsyncClient => CompletableFuture[T]): ZIO[S3, S3Exception, T] =
     ZIO.accessM(_.get.execute(f))

--- a/src/test/scala/zio/s3/S3Test.scala
+++ b/src/test/scala/zio/s3/S3Test.scala
@@ -190,7 +190,7 @@ object S3Suite {
       val tmpKey = Random.alphanumeric.take(10).mkString
 
       for {
-        _ <- multipartUpload(10)(bucketName, tmpKey, "application/octet-stream", data)
+        _ <- multipartUpload(bucketName, tmpKey, "application/octet-stream", data)
         fileSize <- ZFiles
                      .readAttributes[PosixFileAttributes](root / bucketName / tmpKey)
                      .map(_.size())


### PR DESCRIPTION
after some benchmarking on real s3 storage, with a file size of 48M

```scala

(ZIO.effectTotal(System.currentTimeMillis()) <* multipartUpload(
      "regis-leray-bucket-1",
      "upload/electric-motor-temperature.zip",
      "application/zip",
      ZStream
        .fromInputStream(
          new FileInputStream(Paths.get("/Users/regis/Desktop/electric-motor-temperature.zip").toFile)
        )
    )).tap { begin =>
      ZIO.effectTotal(println("multipartUpload : " + (System.currentTimeMillis() - begin)))
    }.repeat(Schedule.recurs(2))
```


time elapsed in microseconds with mapMPar(20)
multipartUpload : 60959
multipartUpload : 55030

time elapsed in microseconds with mapM
multipartUpload : 41556
multipartUpload : 39904
