### PR TITLE
Add support for defining metadata

### DIFF
--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -95,7 +95,8 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
     key: String,
     contentLength: Long,
     contentType: String,
-    content: ZStream[R, Throwable, Byte]
+    content: ZStream[R, Throwable, Byte],
+    metadata: Map[String, String] = Map.empty
   ): ZIO[R, S3Exception, Unit] =
     content
       .mapChunks(Chunk.single)
@@ -110,6 +111,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
               .contentLength(contentLength)
               .contentType(contentType)
               .key(key)
+              .metadata(metadata.asJava)
               .build(),
             AsyncRequestBody.fromPublisher(publisher)
           )
@@ -122,7 +124,8 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
     bucketName: String,
     key: String,
     contentType: String,
-    content: ZStream[R, Throwable, Byte]
+    content: ZStream[R, Throwable, Byte],
+    metadata: Map[String, String] = Map.empty
   ): ZIO[R, S3Exception, Unit] =
     for {
       uploadId <- execute(
@@ -132,6 +135,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
                         .bucket(bucketName)
                         .key(key)
                         .contentType(contentType)
+                        .metadata(metadata.asJava)
                         .build()
                     )
                   ).map(_.uploadId())

--- a/src/main/scala/zio/s3/Test.scala
+++ b/src/main/scala/zio/s3/Test.scala
@@ -102,7 +102,8 @@ object Test {
         key: String,
         contentLength: Long,
         contentType: String,
-        content: ZStream[R, Throwable, Byte]
+        content: ZStream[R, Throwable, Byte],
+        metadata: Map[String, String]
       ): ZIO[R, S3Exception, Unit] =
         ZManaged
           .fromAutoCloseable(Task(new FileOutputStream((path / bucketName / key).toFile)))
@@ -121,9 +122,10 @@ object Test {
         bucketName: String,
         key: String,
         contentType: String,
-        content: ZStream[R, Throwable, Byte]
+        content: ZStream[R, Throwable, Byte],
+        metadata: Map[String, String]
       ): ZIO[R, S3Exception, Unit] =
-        putObject(bucketName, key, 0, contentType, content.chunkN(10))
+        putObject(bucketName, key, 0, contentType, content.chunkN(10), metadata)
     }
   }
 }

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -106,6 +106,7 @@ package object s3 {
        * @param contentLength length of the data in bytes
        * @param contentType content type of the object (json, csv, txt, binary, ...)
        * @param content object data
+       * @param metadata metadata
        * @return
        */
       def putObject[R <: zio.Has[_]: Tag](
@@ -113,7 +114,8 @@ package object s3 {
         key: String,
         contentLength: Long,
         contentType: String,
-        content: ZStream[R, Throwable, Byte]
+        content: ZStream[R, Throwable, Byte],
+        metadata: Map[String, String]
       ): ZIO[R, S3Exception, Unit]
 
       /**
@@ -130,7 +132,8 @@ package object s3 {
         bucketName: String,
         key: String,
         contentType: String,
-        content: ZStream[R, Throwable, Byte]
+        content: ZStream[R, Throwable, Byte],
+        metadata: Map[String, String]
       ): ZIO[R, S3Exception, Unit]
 
       /**
@@ -235,17 +238,19 @@ package object s3 {
     key: String,
     contentLength: Long,
     contentType: String,
-    content: ZStream[R, Throwable, Byte]
+    content: ZStream[R, Throwable, Byte],
+    metadata: Map[String, String]
   ): ZIO[S3 with R, S3Exception, Unit] =
-    ZIO.accessM[S3 with R](_.get.putObject(bucketName, key, contentLength, contentType, content))
+    ZIO.accessM[S3 with R](_.get.putObject(bucketName, key, contentLength, contentType, content, metadata))
 
   def multipartUpload[R <: Has[_]: Tag](
     bucketName: String,
     key: String,
     contentType: String,
-    content: ZStream[R, Throwable, Byte]
+    content: ZStream[R, Throwable, Byte],
+    metadata: Map[String, String]
   ): ZIO[S3 with R, S3Exception, Unit] =
-    ZIO.accessM[S3 with R](_.get.multipartUpload(bucketName, key, contentType, content))
+    ZIO.accessM[S3 with R](_.get.multipartUpload(bucketName, key, contentType, content, metadata))
 
   def execute[T](f: S3AsyncClient => CompletableFuture[T]): ZIO[S3, S3Exception, T] =
     ZIO.accessM(_.get.execute(f))

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -115,7 +115,7 @@ package object s3 {
         contentLength: Long,
         contentType: String,
         content: ZStream[R, Throwable, Byte],
-        metadata: Map[String, String]
+        metadata: Map[String, String] = Map.empty
       ): ZIO[R, S3Exception, Unit]
 
       /**
@@ -133,7 +133,7 @@ package object s3 {
         key: String,
         contentType: String,
         content: ZStream[R, Throwable, Byte],
-        metadata: Map[String, String]
+        metadata: Map[String, String] = Map.empty
       ): ZIO[R, S3Exception, Unit]
 
       /**

--- a/src/test/scala/zio/s3/S3Test.scala
+++ b/src/test/scala/zio/s3/S3Test.scala
@@ -169,7 +169,7 @@ object S3Suite {
         val tmpKey = Random.alphanumeric.take(10).mkString
 
         for {
-          _        <- putObject(bucketName, tmpKey, c.length.toLong, "text/plain", data)
+          _        <- putObject(bucketName, tmpKey, c.length.toLong, "text/plain", data, metadata = Map.empty)
           fileSize <- (ZFiles
                           .readAttributes[PosixFileAttributes](root / bucketName / tmpKey)
                           .map(_.size()) <* ZFiles.delete(root / bucketName / tmpKey)).provideLayer(Blocking.live)
@@ -197,7 +197,7 @@ object S3Suite {
         val tmpKey = Random.alphanumeric.take(10).mkString
 
         for {
-          _        <- multipartUpload(bucketName, tmpKey, "application/octet-stream", data)
+          _        <- multipartUpload(bucketName, tmpKey, "application/octet-stream", data, metadata = Map.empty)
           fileSize <- (ZFiles
                           .readAttributes[PosixFileAttributes](root / bucketName / tmpKey)
                           .map(_.size()) <* ZFiles.delete(root / bucketName / tmpKey)).provideLayer(Blocking.live)


### PR DESCRIPTION
I'm working on a project where I need to update the metadata to do something business relevant.

I thought about going around this one similar to how I'm already fetching the metadata i.e. by using `execute` but as you can see here this is only possible if I copy the file again, this is not optimal for my use-case.

This needs to be provided when creating the s3 object as seen here: https://stackoverflow.com/a/32646827/7413631

For now, I just added what I need, i.e. a map of metadata, possibly we could think about some quality tests/type safety.