### PR TITLE
Fin the environment type in putObject and multipartUpload

### DIFF
--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -29,7 +29,7 @@ import zio.interop.reactivestreams._
 import zio.s3.Live.{ S3ExceptionUtils, StreamAsyncResponseTransformer, StreamResponse }
 import zio.s3.S3Bucket.S3BucketListing
 import zio.stream.{ Stream, ZSink, ZStream }
-import zio.{ Tag, _ }
+import zio._
 
 import scala.jdk.CollectionConverters._
 
@@ -95,7 +95,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
         ).map(S3ObjectListing.fromResponse)
       }
 
-  override def putObject[R <: zio.Has[_]: Tag](
+  override def putObject[R](
     bucketName: String,
     key: String,
     contentLength: Long,
@@ -127,7 +127,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
       )
       .unit
 
-  def multipartUpload[R <: zio.Has[_]: Tag](
+  def multipartUpload[R](
     bucketName: String,
     key: String,
     content: ZStream[R, Throwable, Byte],

--- a/src/main/scala/zio/s3/Test.scala
+++ b/src/main/scala/zio/s3/Test.scala
@@ -27,11 +27,11 @@ import software.amazon.awssdk.services.s3.model.S3Exception
 import zio._
 import zio.blocking.Blocking
 import zio.nio.channels.FileChannel
-import zio.nio.core.file.{Path => ZPath}
+import zio.nio.core.file.{ Path => ZPath }
 import zio.nio.file.Files
 import zio.s3.Live.S3ExceptionUtils
 import zio.s3.S3Bucket._
-import zio.stream.{Stream, ZStream}
+import zio.stream.{ Stream, ZStream }
 
 /**
  * Stub Service which is back by a filesystem storage

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -117,7 +117,7 @@ package object s3 {
        * @param content object data
        * @return
        */
-      def putObject[R <: zio.Has[_]: Tag](
+      def putObject[R](
         bucketName: String,
         key: String,
         contentLength: Long,
@@ -136,7 +136,7 @@ package object s3 {
        * @param options the optional configurations of the multipart upload
        * @param parallelism the number of parallel requests to upload chunks
        */
-      def multipartUpload[R <: zio.Has[_]: Tag](
+      def multipartUpload[R](
         bucketName: String,
         key: String,
         content: ZStream[R, Throwable, Byte],
@@ -249,7 +249,7 @@ package object s3 {
   def getNextObjects(listing: S3ObjectListing): ZIO[S3, S3Exception, S3ObjectListing] =
     ZIO.accessM(_.get.getNextObjects(listing))
 
-  def putObject[R <: Has[_]: Tag](
+  def putObject[R](
     bucketName: String,
     key: String,
     contentLength: Long,
@@ -266,7 +266,7 @@ package object s3 {
    * @param content object data
    * @param options the optional configurations of the multipart upload
    */
-  def multipartUpload_[R <: Has[_]: Tag](
+  def multipartUpload_[R](
     bucketName: String,
     key: String,
     content: ZStream[R, Throwable, Byte],
@@ -276,7 +276,7 @@ package object s3 {
       _.get.multipartUpload(bucketName, key, content, options)(1)
     )
 
-  def multipartUpload[R <: Has[_]: Tag](
+  def multipartUpload[R](
     bucketName: String,
     key: String,
     content: ZStream[R, Throwable, Byte],


### PR DESCRIPTION
The environment does not necessarily contain the `Has` in it. 
An example that reproduces the issues with the environment type is:
```
val s3: S3.Service = ???
val res: ZIO[Nothing, S3Exception, Unit] = s3.multipartUpload("bucket", "key", ZStream.empty)(1)
```
The environment type should be `Any` instead of `Nothing` like this:
```
val res: ZIO[Any, S3Exception, Unit] = s3.multipartUpload("bucket", "key", ZStream.empty)(1)
```