### PR TITLE
Move "listObjectsDescendant" into the S3.Service

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -32,7 +32,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception
   // list all objects of all buckets
   val l2: ZStream[S3, S3Exception, String] = (for {
      bucket <- ZStream.fromIterableM(listBuckets) 
-     obj <- listObjectsDescendant(bucket.name, "")
+     obj <- listAllObjects(bucket.name, "")
   } yield obj.bucketName + "/" + obj.key).provideLayer(
      live("us-east-1", S3Credentials("accessKeyId", "secretAccessKey"))
   )  

--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -20,16 +20,16 @@ import java.net.URI
 import java.nio.ByteBuffer
 import java.util.concurrent.CompletableFuture
 
-import software.amazon.awssdk.auth.credentials.{AwsBasicCredentials, StaticCredentialsProvider}
-import software.amazon.awssdk.core.async.{AsyncRequestBody, AsyncResponseTransformer, SdkPublisher}
+import software.amazon.awssdk.auth.credentials.{ AwsBasicCredentials, StaticCredentialsProvider }
+import software.amazon.awssdk.core.async.{ AsyncRequestBody, AsyncResponseTransformer, SdkPublisher }
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model._
 import zio._
 import zio.interop.reactivestreams._
-import zio.s3.Live.{S3ExceptionUtils, StreamAsyncResponseTransformer, StreamResponse}
+import zio.s3.Live.{ S3ExceptionUtils, StreamAsyncResponseTransformer, StreamResponse }
 import zio.s3.S3Bucket.S3BucketListing
-import zio.stream.{Stream, ZSink, ZStream}
+import zio.stream.{ Stream, ZSink, ZStream }
 
 import scala.jdk.CollectionConverters._
 

--- a/src/main/scala/zio/s3/Test.scala
+++ b/src/main/scala/zio/s3/Test.scala
@@ -22,7 +22,6 @@ import java.nio.file.attribute.PosixFileAttributes
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
 
-import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.S3Exception
 import zio._
@@ -196,13 +195,6 @@ object Test {
                )
         } yield ()
       }
-
-      override def executePublisher[T](f: S3AsyncClient => SdkPublisher[T]): ZStream[Any, S3Exception, T] =
-        ZStream.fail(
-          S3ExceptionUtils.fromThrowable(
-            new NotImplementedError("Not implemented error - please don't call executePublisher() in S3 Test mode")
-          )
-        )
     }
   }
 }

--- a/src/main/scala/zio/s3/Test.scala
+++ b/src/main/scala/zio/s3/Test.scala
@@ -28,11 +28,11 @@ import software.amazon.awssdk.services.s3.model.S3Exception
 import zio._
 import zio.blocking.Blocking
 import zio.nio.channels.FileChannel
-import zio.nio.core.file.{Path => ZPath}
+import zio.nio.core.file.{ Path => ZPath }
 import zio.nio.file.Files
 import zio.s3.Live.S3ExceptionUtils
 import zio.s3.S3Bucket._
-import zio.stream.{Stream, ZStream}
+import zio.stream.{ Stream, ZStream }
 
 /**
  * Stub Service which is back by a filesystem storage

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -187,7 +187,7 @@ package object s3 {
   def stub(path: ZPath): ZLayer[Blocking, Any, S3] =
     ZLayer.fromFunction(Test.connect(path))
 
-  def listAllObjects(bucketName: String, prefix: String): S3Stream[S3ObjectSummary] =
+  def listAllObjects(bucketName: String, prefix: String = ""): S3Stream[S3ObjectSummary] =
     ZStream.accessStream(_.get.listAllObjects(bucketName, prefix))
 
   /**
@@ -248,7 +248,11 @@ package object s3 {
   def listObjects_(bucketName: String): ZIO[S3, S3Exception, S3ObjectListing] =
     ZIO.accessM(_.get.listObjects(bucketName, "", 1000))
 
-  def listObjects(bucketName: String, prefix: String, maxKeys: Long): ZIO[S3, S3Exception, S3ObjectListing] =
+  def listObjects(
+    bucketName: String,
+    prefix: String = "",
+    maxKeys: Long = 1000
+  ): ZIO[S3, S3Exception, S3ObjectListing] =
     ZIO.accessM(_.get.listObjects(bucketName, prefix, maxKeys))
 
   def getNextObjects(listing: S3ObjectListing): ZIO[S3, S3Exception, S3ObjectListing] =

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -19,7 +19,6 @@ package zio
 import java.net.URI
 import java.util.concurrent.CompletableFuture
 
-import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.S3Exception
@@ -160,13 +159,6 @@ package object s3 {
        * @tparam T value type to return
        */
       def execute[T](f: S3AsyncClient => CompletableFuture[T]): IO[S3Exception, T]
-
-      /**
-       * Expose the s3 async client publisher as a ZStream
-       * @param f a call on an s3 async client with the streaming response
-       * @tparam T value type to return
-       */
-      def executePublisher[T](f: S3AsyncClient => SdkPublisher[T]): ZStream[Any, S3Exception, T]
     }
   }
 

--- a/src/main/scala/zio/s3/s3model.scala
+++ b/src/main/scala/zio/s3/s3model.scala
@@ -46,12 +46,20 @@ object S3ObjectListing {
   def fromResponse(r: ListObjectsV2Response): S3ObjectListing =
     S3ObjectListing(
       r.name(),
-      Chunk.fromIterable(r.contents().asScala.toList).map(o => S3ObjectSummary(r.name(), o.key())),
+      S3ObjectSummary.fromResponse(r),
       Option(r.nextContinuationToken())
     )
 }
 
-final case class S3ObjectSummary(bucketName: String, key: String)
+final case class S3ObjectSummary(bucketName: String, key: String, lastModified: Instant, size: Long)
+
+object S3ObjectSummary {
+
+  def fromResponse(response: ListObjectsV2Response) =
+    Chunk
+      .fromIterable(response.contents().asScala.toList)
+      .map(obj => S3ObjectSummary(response.name, obj.key, obj.lastModified, obj.size))
+}
 
 /**
  * @param metadata the user-defined metadata without the "x-amz-meta-" prefix

--- a/src/test/scala/zio/s3/S3Test.scala
+++ b/src/test/scala/zio/s3/S3Test.scala
@@ -6,12 +6,12 @@ import java.util.UUID
 
 import software.amazon.awssdk.regions.Region
 import zio.blocking.Blocking
-import zio.nio.core.file.{Path => ZPath}
-import zio.nio.file.{Files => ZFiles}
-import zio.stream.{ZStream, ZTransducer}
+import zio.nio.core.file.{ Path => ZPath }
+import zio.nio.file.{ Files => ZFiles }
+import zio.stream.{ ZStream, ZTransducer }
 import zio.test.Assertion._
 import zio.test._
-import zio.{Chunk, ZLayer}
+import zio.{ Chunk, ZLayer }
 
 import scala.util.Random
 
@@ -54,7 +54,9 @@ object S3Suite {
       testM("list objects") {
         for {
           succeed <- listObjects_(bucketName)
-        } yield assert(succeed.bucketName)(equalTo(bucketName)) && assert(succeed.objectSummaries.map(summaryDecreaseTimePrecision))(
+        } yield assert(succeed.bucketName)(equalTo(bucketName)) && assert(
+          succeed.objectSummaries.map(summaryDecreaseTimePrecision)
+        )(
           hasSameElements(
             List(
               S3ObjectSummary(bucketName, "console.log", Instant.parse("2020-09-09T17:55:40Z"), 33),


### PR DESCRIPTION
There are multiple operators that return an SdkPublisher in the response. One of them is `listObjectsV2Paginator` which returns all the objects instead of one page.

`listObjectsDescendant` is reimplemented based on the streaming operator. The `listAllObjects` is also added into the Service so that the code that is based on ZLayers can inject the Service and use the `listObjectsDescendant`.

`S3ObjectSummary` is extended with additional fields. I have a use case to filter the objects based on the creation time.