### PR TITLE
Don't wrap upstream errors

### DIFF
--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -26,7 +26,7 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model._
 import zio.interop.reactivestreams._
-import zio.s3.Live.{ S3ExceptionUtils, StreamAsyncResponseTransformer, StreamResponse }
+import zio.s3.Live.{ StreamAsyncResponseTransformer, StreamResponse }
 import zio.s3.S3Bucket.S3BucketListing
 import zio.stream.{ Stream, ZSink, ZStream }
 import zio._
@@ -69,7 +69,9 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
       )
       .flatMap(identity)
       .flattenChunks
-      .mapError(S3ExceptionUtils.fromThrowable)
+      .refineOrDie {
+        case e: S3Exception => e
+      }
 
   override def getObjectMetadata(bucketName: String, key: String): IO[S3Exception, ObjectMetadata] =
     execute(_.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build()))
@@ -134,23 +136,13 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
     options: MultipartUploadOptions
   )(parallelism: Int): ZIO[R, S3Exception, Unit] =
     for {
-      _        <- ZIO.cond(
-                    parallelism > 0,
-                    (),
-                    S3ExceptionUtils.fromThrowable(
-                      new IllegalArgumentException(s"parallelism must be > 0. $parallelism is invalid")
-                    )
-                  )
-
-      _        <- ZIO.cond(
-                    options.partSize >= PartSize.Min,
-                    (),
-                    S3ExceptionUtils.fromThrowable(
-                      new IllegalArgumentException(
-                        s"Invalid part size ${Math.floor(options.partSize.toDouble / PartSize.Mega.toDouble * 100d) / 100d} Mb, minimum size is ${PartSize.Min / PartSize.Mega} Mb"
-                      )
-                    )
-                  )
+      _        <- ZIO.dieMessage(s"parallelism must be > 0. $parallelism is invalid").unless(parallelism > 0)
+      _        <-
+        ZIO
+          .dieMessage(
+            s"Invalid part size ${Math.floor(options.partSize.toDouble / PartSize.Mega.toDouble * 100d) / 100d} Mb, minimum size is ${PartSize.Min / PartSize.Mega} Mb"
+          )
+          .unless(options.partSize >= PartSize.Min)
 
       uploadId <- execute(
                     _.createMultipartUpload {
@@ -195,7 +187,9 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
                         ).map(r => CompletedPart.builder().partNumber(partNumber.toInt + 1).eTag(r.eTag()).build())
                     }
                     .runCollect
-                    .mapError(S3ExceptionUtils.fromThrowable)
+                    .refineOrDie {
+                      case e: S3Exception => e
+                    }
 
       _        <- execute(
                     _.completeMultipartUpload(
@@ -243,12 +237,6 @@ object Live {
       )
       .map(new Live(_))
       .mapError(e => ConnectionError(e.getMessage, e.getCause))
-
-  object S3ExceptionUtils {
-
-    private[s3] def fromThrowable(error: Throwable): S3Exception =
-      S3Exception.builder().message(error.getMessage).cause(error.getCause).build().asInstanceOf[S3Exception]
-  }
 
   type StreamResponse = ZStream[Any, Throwable, Chunk[Byte]]
 

--- a/src/test/scala/zio/s3/S3Test.scala
+++ b/src/test/scala/zio/s3/S3Test.scala
@@ -218,22 +218,14 @@ object S3Suite {
       testM("multipart with invalid parallelism value 0") {
         val data   = ZStream.empty
         val tmpKey = Random.alphanumeric.take(10).mkString
-
-        for {
-          failure <- multipartUpload(bucketName, tmpKey, data)(0)
-                       .foldCause(_.failureOption.map(_.getMessage).mkString, _ => "")
-
-        } yield assert(failure)(equalTo(s"parallelism must be > 0. 0 is invalid"))
+        val io     = multipartUpload(bucketName, tmpKey, data)(0)
+        assertM(io.run)(dies(hasMessage(equalTo("parallelism must be > 0. 0 is invalid"))))
       },
       testM("multipart with invalid partSize value 0") {
         val tmpKey        = Random.alphanumeric.take(10).mkString
         val invalidOption = MultipartUploadOptions(partSize = 0)
-
-        for {
-          failure <- multipartUpload_(bucketName, tmpKey, ZStream.empty, invalidOption)
-                       .foldCause(_.failureOption.map(_.getMessage).mkString, _ => "")
-
-        } yield assert(failure)(equalTo(s"Invalid part size 0.0 Mb, minimum size is 5 Mb"))
+        val io            = multipartUpload_(bucketName, tmpKey, ZStream.empty, invalidOption)
+        assertM(io.run)(dies(hasMessage(equalTo(s"Invalid part size 0.0 Mb, minimum size is 5 Mb"))))
       },
       testM("multipart object when the content is empty") {
         val data   = ZStream.empty


### PR DESCRIPTION
Currently `S3ExceptionUtils#fromThrowable` will wrap upstream S3Exceptions but not set statuscode, etc correctly.
This can for example, lead to hard to debug issues if trying to check for 404s, etc.
 
Generally, I think it's preferable to not wrap upstream errors and let misconfiguration, etc. just kill the fiber.
I'm unsure how far we should go with providing 'sane' errors in the Test implementation.

/cc @mijicd 