### PR TITLE
use environment in connect and liveM

### DIFF
--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -227,9 +227,9 @@ object Live {
 
   def connect[R](
     region: S3Region,
-    provider: TaskManaged[AwsCredentialsProvider],
+    provider: RManaged[R, AwsCredentialsProvider],
     uriEndpoint: Option[URI]
-  ): Managed[ConnectionError, S3.Service] =
+  ): ZManaged[R, ConnectionError, S3.Service] =
     (for {
       credentials <- provider
       s           <- ZManaged

--- a/src/main/scala/zio/s3/package.scala
+++ b/src/main/scala/zio/s3/package.scala
@@ -203,11 +203,11 @@ package object s3 {
   def live(region: Region, credentials: AwsCredentials, uriEndpoint: Option[URI] = None): Layer[S3Exception, S3] =
     liveM(region, CredentialsProviders.const(credentials.accessKeyId, credentials.secretAccessKey), uriEndpoint)
 
-  def liveM(
+  def liveM[R](
     region: Region,
-    provider: TaskManaged[AwsCredentialsProvider],
+    provider: RManaged[R, AwsCredentialsProvider],
     uriEndpoint: Option[URI] = None
-  ): Layer[S3Exception, S3] =
+  ): ZLayer[R, S3Exception, S3] =
     ZLayer.fromManaged(
       ZManaged
         .fromEffect(ZIO.fromEither(S3Region.from(region)))

--- a/src/test/scala/zio/s3/S3LayerTest.scala
+++ b/src/test/scala/zio/s3/S3LayerTest.scala
@@ -1,0 +1,15 @@
+package zio.s3
+
+import java.net.URI
+import software.amazon.awssdk.regions.Region
+import zio.test.Assertion._
+import zio.test._
+
+object S3LayerSpec extends DefaultRunnableSpec {
+  override def spec =
+    suite("S3LayerSpec")(
+      testM("using ZManaged[R, E, A] in liveM compiles") {
+        assertM(typeCheck("""liveM(Region.CA_CENTRAL_1, CredentialsProviders.default, Some(URI.create("http://localhost:9000")))"""))(isRight)
+      }
+    )
+}

--- a/src/test/scala/zio/s3/S3LayerTest.scala
+++ b/src/test/scala/zio/s3/S3LayerTest.scala
@@ -6,10 +6,15 @@ import zio.test.Assertion._
 import zio.test._
 
 object S3LayerSpec extends DefaultRunnableSpec {
+
   override def spec =
     suite("S3LayerSpec")(
       testM("using ZManaged[R, E, A] in liveM compiles") {
-        assertM(typeCheck("""liveM(Region.CA_CENTRAL_1, CredentialsProviders.default, Some(URI.create("http://localhost:9000")))"""))(isRight)
+        assertM(
+          typeCheck(
+            """liveM(Region.CA_CENTRAL_1, CredentialsProviders.default, Some(URI.create("http://localhost:9000")))"""
+          )
+        )(isRight)
       }
     )
 }


### PR DESCRIPTION
I noticed that some of the examples in the quickstart don't work, see [here](https://github.com/zio/zio-s3/blob/5ba2fa473c0e8f4c557ff4e26fc51aa6938d2531/docs/quickstart/index.md#credentials).
Added test to assert it can be constructed (fails on current 0.3.2) and implemented needed change.