### PR TITLE
Use grouped to group bytes in multipart requests

### DIFF
--- a/src/main/scala/zio/s3/Live.scala
+++ b/src/main/scala/zio/s3/Live.scala
@@ -178,8 +178,7 @@ final class Live(unsafeClient: S3AsyncClient) extends S3.Service {
       parts    <- ZStream
                     .managed(
                       content
-                        .chunkN(options.partSize)
-                        .mapChunks(Chunk.single)
+                        .grouped(options.partSize)
                         .peel(ZSink.head[Chunk[Byte]])
                     )
                     .flatMap {


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/zio/zio/issues/6399), there are situations where you can run into memory issues when using the original code. Using `grouped` seems to fix these issues for us.

Of course we could also wait until the original issue is fixed, but I think the behaviour of these operators should be the same. 