### PR TITLE
[FEATURE] Add contentMD5 for `putObject` to support object locking

### DIFF
--- a/zio-s3/src/main/scala/zio/s3/S3.scala
+++ b/zio-s3/src/main/scala/zio/s3/S3.scala
@@ -2,10 +2,10 @@ package zio.s3
 
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.S3Exception
-import zio.{ IO, ZIO }
-import zio.s3.errors.DecodingException
 import zio.s3.S3Bucket.S3BucketListing
+import zio.s3.errors.DecodingException
 import zio.stream.{ Stream, ZPipeline, ZStream }
+import zio.{ IO, ZIO }
 
 import java.nio.charset.CharacterCodingException
 import java.util.concurrent.CompletableFuture
@@ -88,10 +88,24 @@ trait S3 { self =>
   /**
    * Store data object into a specific bucket
    *
+   * ==Example of creating a contentMD5 option==
+   *
+   * The md5 option is required when the target bucket is configured with object locking, otherwise
+   * the AWS S3 API will not accept the [[putObject]] request.
+   *
+   * {{{
+   *  import software.amazon.awssdk.utils.Md5Utils
+   *  import scala.util.Random
+   *
+   *  val bytes  = Random.nextString(65536).getBytes()
+   *  val contentMD5 = Some(Md5Utils.md5AsBase64(bytes))
+   * }}}
+   *
    * @param bucketName name of the bucket
    * @param key unique object identifier
    * @param contentLength length of the data in bytes
    * @param content object data
+   * @param contentMD5 [[Option]] of [[String]] containing the MD5 hash of the content encoded as base64
    * @return
    */
   def putObject[R](
@@ -99,7 +113,8 @@ trait S3 { self =>
     key: String,
     contentLength: Long,
     content: ZStream[R, Throwable, Byte],
-    options: UploadOptions = UploadOptions.default
+    options: UploadOptions = UploadOptions.default,
+    contentMD5: Option[String] = None
   ): ZIO[R, S3Exception, Unit]
 
   /**

--- a/zio-s3/src/main/scala/zio/s3/S3.scala
+++ b/zio-s3/src/main/scala/zio/s3/S3.scala
@@ -105,7 +105,7 @@ trait S3 { self =>
    * @param key unique object identifier
    * @param contentLength length of the data in bytes
    * @param content object data
-   * @param contentMD5 [[Option]] of [[String]] containing the MD5 hash of the content encoded as base64
+   * @param contentMD5 a String Option containing the MD5 hash of the content encoded as base64
    * @return
    */
   def putObject[R](

--- a/zio-s3/src/main/scala/zio/s3/package.scala
+++ b/zio-s3/src/main/scala/zio/s3/package.scala
@@ -21,8 +21,8 @@ import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.S3Exception
 import zio.nio.file.{ Path => ZPath }
-import zio.s3.errors._
 import zio.s3.S3Bucket.S3BucketListing
+import zio.s3.errors._
 import zio.s3.providers.const
 import zio.stream.ZStream
 
@@ -108,9 +108,10 @@ package object s3 {
     key: String,
     contentLength: Long,
     content: ZStream[R, Throwable, Byte],
-    options: UploadOptions = UploadOptions.default
+    options: UploadOptions = UploadOptions.default,
+    contentMD5: Option[String] = None
   ): ZIO[S3 with R, S3Exception, Unit] =
-    ZIO.serviceWithZIO[S3](_.putObject(bucketName, key, contentLength, content, options))
+    ZIO.serviceWithZIO[S3](_.putObject(bucketName, key, contentLength, content, options, contentMD5))
 
   /**
    * Same as multipartUpload with default parallelism = 1

--- a/zio-s3/src/main/scala/zio/s3/s3model.scala
+++ b/zio-s3/src/main/scala/zio/s3/s3model.scala
@@ -16,11 +16,10 @@
 
 package zio.s3
 
-import java.time.Instant
-
 import software.amazon.awssdk.services.s3.model.{ Bucket, HeadObjectResponse, ListObjectsV2Response }
 import zio.Chunk
 
+import java.time.Instant
 import scala.jdk.CollectionConverters._
 
 final case class S3Bucket(name: String, creationDate: Instant)
@@ -69,11 +68,23 @@ final case class S3ObjectSummary(bucketName: String, key: String, lastModified: 
  * @param metadata the user-defined metadata without the "x-amz-meta-" prefix
  * @param contentType the content type of the object (application/json, application/zip, text/plain, ...)
  * @param contentLength the size of the object in bytes
+ * @param eTag the etag for the response as hex string
  */
-final case class ObjectMetadata(metadata: Map[String, String], contentType: String, contentLength: Long)
+final case class ObjectMetadata(
+  metadata: Map[String, String],
+  contentType: String,
+  contentLength: Long,
+  eTag: String
+)
 
 object ObjectMetadata {
 
   def fromResponse(r: HeadObjectResponse): ObjectMetadata =
-    ObjectMetadata(r.metadata().asScala.toMap, r.contentType(), r.contentLength())
+    ObjectMetadata(
+      r.metadata().asScala.toMap,
+      r.contentType(),
+      r.contentLength(),
+      // ETag is including quotes
+      r.eTag().replace("\"", "")
+    )
 }


### PR DESCRIPTION
### Motivation

We are hitting an error when using this library because our bucket is configured with [object locking](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html):

```
Content-MD5 OR x-amz-checksum- HTTP header is required for Put Object requests with Object Lock parameters
(Service: S3, Status Code: 400, Request ID: XXX, Extended Request ID: XXX)
```

The AWS S3 API requires passing the `Content-MD5` option for `putObject` requests that target buckets with object locking enabled.

From the [`putObject` API description](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html):

> To ensure that data is not corrupted traversing the network, use the Content-MD5 header.
  When you use this header, Amazon S3 checks the object against the provided MD5 value and,
  if they do not match, returns an error. Additionally, you can calculate the MD5 while
  putting an object to Amazon S3 and compare the returned ETag to the calculated MD5 value.

> The Content-MD5 header is required for any request to upload an object with a retention
  period configured using Amazon S3 Object Lock. For more information about Amazon S3 Object
  Lock, see Amazon S3 Object Lock Overview in the Amazon S3 User Guide.

This MR adds a BC support for passing an `Option[String]` as contentMD5, which is a base64 encoded MD5 hash. The library users will be responsible to provide a correct contentMD5.

### Urgency

This is extremely urgent for us since it blocks the go-live of an important project. So if you @regis-leray could have a look shortly and hopefully merge this change to the lib we could use a snapshot version to start our go-live. Thank you very much in advance!
