### PR TITLE
ci: fix+modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   auto-approve:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: hmarr/auto-approve-action@v3.1.0
         if: github.actor == 'scala-steward' || github.actor == 'renovate[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,50 +14,57 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - name: Setup Scala and Java
-        uses: olafurpg/setup-scala@v13
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+          apps: sbt
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Lint code
         run: sbt check
 
   mdoc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.3.0
-      - name: Setup Scala and Java
-        uses: olafurpg/setup-scala@v13
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+          apps: sbt
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Check Document Generation
         run: sbt docs/compileDocs
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        java: ['amazon-corretto@1.17']
+        java: ['11', '17', '21']
         scala: ['2.12.15', '2.13.14', '3.3.3']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - name: Setup Scala and Java
-        uses: olafurpg/setup-scala@v13
+      - name: Setup Action
+        uses: coursier/setup-action@v1
         with:
-          java-version: ${{ matrix.java }}
+          jvm: temurin:${{ matrix.java }}
+          apps: sbt
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Start containers
@@ -67,21 +74,22 @@ jobs:
         run: ./sbt ++${{ matrix.scala }} test
 
   testJvms:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        java: ['17', '21']
+        java: ['11', '17', '21']
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - name: Setup Scala and Java
-        uses: olafurpg/setup-scala@v13
+      - name: Setup Action
+        uses: coursier/setup-action@v1
         with:
-          java-version: ${{ matrix.java }}
+          jvm: temurin:${{ matrix.java }}
+          apps: sbt
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Start containers
@@ -91,14 +99,14 @@ jobs:
         run: ./sbt test
 
   ci:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [lint, mdoc, test, testJvms]
     steps:
       - name: Report successful build
         run: echo "ci passed"
 
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [ci]
     if: github.event_name != 'pull_request'
@@ -107,8 +115,11 @@ jobs:
         uses: actions/checkout@v3.3.0
         with:
           fetch-depth: 0
-      - name: Setup Scala and Java
-        uses: olafurpg/setup-scala@v13
+      - name: Setup Action
+        uses: coursier/setup-action@v1
+        with:
+          jvm: temurin:21
+          apps: sbt
       - name: Cache scala dependencies
         uses: coursier/cache-action@v6
       - name: Release artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         uses: coursier/cache-action@v6
       - name: Start containers
         run: |
-            docker compose -f "docker-compose.yml" up -d --build
+          docker compose -f "docker-compose.yml" up -d --build
       - name: Test
         run: ./sbt ++${{ matrix.scala }} test
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -21,16 +21,13 @@ jobs:
       uses: actions/checkout@v3.3.0
       with:
         fetch-depth: '0'
-    - name: Setup Scala
-      uses: actions/setup-java@v3.9.0
+    - name: Setup Action
+      uses: coursier/setup-action@v1
       with:
-        distribution: temurin
-        java-version: 17
-        check-latest: true
+        jvm: temurin:21
+        apps: sbt
     - name: Check if the README file is up to date
       run: sbt  docs/checkReadme
-    - name: Check if the site workflow is up to date
-      run: sbt  docs/checkGithubWorkflow
     - name: Check artifacts build process
       run: sbt  +publishLocal
     - name: Check website build process
@@ -44,12 +41,11 @@ jobs:
       uses: actions/checkout@v3.3.0
       with:
         fetch-depth: '0'
-    - name: Setup Scala
-      uses: actions/setup-java@v3.9.0
+    - name: Setup Action
+      uses: coursier/setup-action@v1
       with:
-        distribution: temurin
-        java-version: 17
-        check-latest: true
+        jvm: temurin:21
+        apps: sbt
     - name: Setup NodeJs
       uses: actions/setup-node@v3
       with:
@@ -69,12 +65,11 @@ jobs:
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: '0'
-    - name: Setup Scala
-      uses: actions/setup-java@v3.9.0
+    - name: Setup Action
+      uses: coursier/setup-action@v1
       with:
-        distribution: temurin
-        java-version: 17
-        check-latest: true
+        jvm: temurin:21
+        apps: sbt
     - name: Generate Readme
       run: sbt  docs/generateReadme
     - name: Commit Changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,10 @@ services:
       - MINIO_ROOT_PASSWORD=TESTSECRET
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     command: server /data --console-address ":9001"
 
   mc:
@@ -24,17 +25,19 @@ services:
     volumes:
       - ./minio/export:/export
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
     environment:
       - MINIO_ROOT_USER=TESTKEY
       - MINIO_ROOT_PASSWORD=TESTSECRET
     entrypoint: >
       /bin/sh -c "
-      echo Waiting for minio service to start...;
-      curl --retry 10 --retry-delay 10 -s -o /dev/null http://minio:9000/minio/health/live
+      echo Waiting for minio service to be ready...;
+      curl --retry 30 --retry-delay 2 -s -o /dev/null http://minio:9000/minio/health/live
 
-      echo Minio is started;
+      echo Minio is ready;
       /usr/bin/mc config host add my-minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb -p my-minio/bucket-1;
       /usr/bin/mc mirror /export/ my-minio/bucket-1;
+      /usr/bin/mc ls my-minio/bucket-1;
       "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "9001:9001"
     volumes:
       - ./minio/data:/data
+      - ./minio/export:/export
     environment:
       - MINIO_ROOT_USER=TESTKEY
       - MINIO_ROOT_PASSWORD=TESTSECRET
@@ -35,5 +36,5 @@ services:
       echo Minio is started;
       /usr/bin/mc config host add my-minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb -p my-minio/bucket-1;
-      /usr/bin/mc mirror export/ my-minio/bucket-1;
+      /usr/bin/mc mirror /export/ my-minio/bucket-1;
       "


### PR DESCRIPTION
- Update all jobs to use ubuntu-latest
- Replace Java/Scala setup with coursier
- Expand test matrix to cover JDK 11, 17, and 21
- Standardize on JDK 21 for all non-test jobs