### PR TITLE
fix: use mc alias instead of deprecated mc config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All available s3 combinators and operations are available in the package object 
 In order to use this library, we need to add the following line in our `build.sbt` file:
 
 ```scala
-libraryDependencies += "dev.zio" %% "zio-s3" % "0.4.3"
+libraryDependencies += "dev.zio" %% "zio-s3" % "0.4.4"
 ```
 
 ## Example 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,10 +33,8 @@ services:
     entrypoint: >
       /bin/sh -c "
       echo Waiting for minio service to be ready...;
-      curl --retry 30 --retry-delay 2 -s -o /dev/null http://minio:9000/minio/health/live
-
       echo Minio is ready;
-      /usr/bin/mc config host add my-minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
+      /usr/bin/mc alias set my-minio http://minio:9000 $${MINIO_ROOT_USER} $${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb -p my-minio/bucket-1;
       /usr/bin/mc mirror /export/ my-minio/bucket-1;
       /usr/bin/mc ls my-minio/bucket-1;


### PR DESCRIPTION
## Summary
- Replace deprecated `mc config host add` with `mc alias set`
- Remove curl health check (mc image doesn't include curl, and `depends_on: service_healthy` already handles readiness)

## Problem
The MinIO client (mc) has deprecated the `config` command.
This was causing test fixtures to not be properly initialized in the MinIO container, resulting in CI test failures for `S3LiveSpec` and `S3LiveHostnameSpec`.
